### PR TITLE
Fixes build issues with openvr-old branch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,10 @@ endif()
 
 add_subdirectory( vsgvr )
 
+# setup relative data install path
+file(RELATIVE_PATH VSGVR_REL_DATADIR ${CMAKE_INSTALL_FULL_BINDIR} ${CMAKE_INSTALL_FULL_DATADIR}/vsgvr)
+add_definitions(-DVSGVR_REL_DATADIR=\"${VSGVR_REL_DATADIR}\")
+
 add_executable( example_vr example_vr.cpp )
 target_link_libraries( example_vr vsg::vsg vsgvr )
 target_include_directories( example_vr PRIVATE 
@@ -68,8 +72,8 @@ if( MSVC )
 endif()
 
 # Copy models into the build dir
-configure_file(models/world/world.vsgt ${CMAKE_CURRENT_BINARY_DIR}/world.vsgt COPYONLY)
-configure_file(models/controller/controller.vsgt ${CMAKE_CURRENT_BINARY_DIR}/controller.vsgt COPYONLY)
-configure_file(models/controller/controller2.vsgt ${CMAKE_CURRENT_BINARY_DIR}/controller2.vsgt COPYONLY)
+configure_file(models/world/world.vsgt ${CMAKE_CURRENT_BINARY_DIR}/share/vsgvr/world.vsgt COPYONLY)
+configure_file(models/controller/controller.vsgt ${CMAKE_CURRENT_BINARY_DIR}/share/vsgvr/controller.vsgt COPYONLY)
+configure_file(models/controller/controller2.vsgt ${CMAKE_CURRENT_BINARY_DIR}/share/vsgvr/controller2.vsgt COPYONLY)
 
 add_subdirectory( tests )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,10 @@ cmake_minimum_required(VERSION 3.14)
 
 project(VSGVR)
 
+option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
+
+include(GNUInstallDirs)
+
 include(FetchContent)
 
 if( NOT CMAKE_BUILD_TYPE AND NOT MSVC )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ project(vsgvr
     LANGUAGES CXX
 )
 
+set(VSGVR_SOVERSION 0)
+
 include(FetchContent)
 
 # Compiler/Tool requirements

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,23 @@ else()
     message(FATAL_ERROR "Could not find openvr development kit")
 endif()
 
+vsg_add_target_clang_format(
+    FILES
+        ${PROJECT_SOURCE_DIR}/vsgvr/include/vsgvr/*.h
+        ${PROJECT_SOURCE_DIR}/vsgvr/srv/vsgvr/*.cpp
+)
+vsg_add_target_cppcheck(
+    FILES
+        ${PROJECT_SOURCE_DIR}/vsgvr/include/vsgvr/*.h
+        ${PROJECT_SOURCE_DIR}/vsgvr/srv/vsgvr/*.cpp
+)
+vsg_add_target_clobber()
+vsg_add_target_docs(
+    FILES
+        ${PROJECT_SOURCE_DIR}/vsgvr/include
+)
+vsg_add_target_uninstall()
+
 #####################
 
 add_subdirectory( vsgvr )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ set(OpenGL_GL_PREFERENCE GLVND)
 # add_subdirectory(deps/Format.cmake)
 
 # Package/System requirements
-find_package(vsg REQUIRED)
+find_package(vsg 1.0.0 REQUIRED)
 find_package(Vulkan REQUIRED)
 
 vsg_setup_dir_vars()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,3 +105,6 @@ install(FILES
 )
 
 add_subdirectory( tests )
+
+vsg_add_feature_summary()
+

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,15 +22,36 @@ find_package(Vulkan REQUIRED)
 vsg_setup_dir_vars()
 vsg_setup_build_vars()
 
-# TODO: openvr paths are hardcoded
-set( OPENVR_ROOT ${PROJECT_SOURCE_DIR}/deps/openvr )
-set( OPENVR_LIB "openvr_api" )
-if( MSVC )
-  set( OPENVR_BINDIR ${OPENVR_ROOT}/bin/win64 )
-  set( OPENVR_LIBDIR ${OPENVR_ROOT}/lib/win64 )
+find_package(PkgConfig)
+if (PKG_CONFIG_FOUND)
+    pkg_search_module(OPENVR openvr)
+endif()
+if (OPENVR_FOUND)
+    set(OPENVR_LIB ${OPENVR_LIBRARIES})
+    set(OPENVR_LIBDIR ${OPENVR_LIBRARY_DIRS})
+    include(FindPackageHandleStandardArgs)
+    find_package_handle_standard_args(openvr
+        FOUND_VAR OPENVR_FOUND
+        REQUIRED_VARS
+            OPENVR_LIBRARIES
+            OPENVR_INCLUDE_DIRS
+        VERSION_VAR OPENVR_VERSION
+    )
+elseif(IS_DIRECTORY deps/openvr)
+    message(STATUS "Using embedded openvr development kit")
+    set(OPENVR_LIB "openvr_api" )
+    set(OPENVR_ROOT ${PROJECT_SOURCE_DIR}/deps/openvr)
+    set(OPENVR_INCLUDE_DIRS ${OPENVR_ROOT}/headers)
+    if( MSVC )
+        set(OPENVR_BINDIR ${OPENVR_ROOT}/bin/win64)
+        set(OPENVR_LIBDIR ${OPENVR_ROOT}/lib/win64)
+    else()
+        set(OPENVR_BINDIR ${OPENVR_ROOT}/bin/linux64)
+        set(OPENVR_LIBDIR ${OPENVR_ROOT}/lib/linux64)
+    endif()
+    add_subdirectory(deps/openvr)
 else()
-  set( OPENVR_BINDIR ${OPENVR_ROOT}/bin/linux64 )
-  set( OPENVR_LIBDIR ${OPENVR_ROOT}/lib/linux64 )
+    message(FATAL_ERROR "Could not find openvr development kit")
 endif()
 
 #####################
@@ -40,7 +61,7 @@ add_subdirectory( vsgvr )
 add_executable( example_vr example_vr.cpp )
 target_link_libraries( example_vr vsg::vsg vsgvr )
 target_include_directories( example_vr PRIVATE 
-  ${OPENVR_ROOT}/headers
+  ${OPENVR_INCLUDE_DIRS}
   vsgvr/include )
 if( MSVC )
   set_target_properties(example_vr PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=${OPENVR_BINDIR}")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,9 +71,18 @@ if( MSVC )
   set_target_properties(example_vr PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=${OPENVR_BINDIR}")
 endif()
 
+install(TARGETS example_vr)
+
 # Copy models into the build dir
 configure_file(models/world/world.vsgt ${CMAKE_CURRENT_BINARY_DIR}/share/vsgvr/world.vsgt COPYONLY)
 configure_file(models/controller/controller.vsgt ${CMAKE_CURRENT_BINARY_DIR}/share/vsgvr/controller.vsgt COPYONLY)
 configure_file(models/controller/controller2.vsgt ${CMAKE_CURRENT_BINARY_DIR}/share/vsgvr/controller2.vsgt COPYONLY)
+
+install(FILES
+    models/world/world.vsgt
+    models/controller/controller.vsgt
+    models/controller/controller2.vsgt
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/vsgvr
+)
 
 add_subdirectory( tests )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,17 +1,12 @@
 cmake_minimum_required(VERSION 3.14)
 
-project(VSGVR)
-
-option(BUILD_SHARED_LIBS "Build shared libraries" OFF)
-
-include(GNUInstallDirs)
+project(vsgvr
+    VERSION 0.4.0
+    DESCRIPTION "VulkanSceneGraph based virtual reality viewer"
+    LANGUAGES CXX
+)
 
 include(FetchContent)
-
-if( NOT CMAKE_BUILD_TYPE AND NOT MSVC )
-  set( CMAKE_BUILD_TYPE Release CACHE STRING "Choose the type of build." FORCE )
-  set_property( CACHE CMAKE_BUILD_TYPE PROPERTY STRINGS "Release" "Debug" "MinSizeRel" "RelWithDebInfo" )
-endif()
 
 # Compiler/Tool requirements
 set( CMAKE_CXX_STANDARD 17 )
@@ -23,6 +18,9 @@ set(OpenGL_GL_PREFERENCE GLVND)
 # Package/System requirements
 find_package(vsg REQUIRED)
 find_package(Vulkan REQUIRED)
+
+vsg_setup_dir_vars()
+vsg_setup_build_vars()
 
 # TODO: openvr paths are hardcoded
 set( OPENVR_ROOT ${PROJECT_SOURCE_DIR}/deps/openvr )

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,6 +89,7 @@ target_include_directories( example_vr PRIVATE
 if( MSVC )
   set_target_properties(example_vr PROPERTIES VS_DEBUGGER_ENVIRONMENT "PATH=${OPENVR_BINDIR}")
 endif()
+set_target_properties(example_vr PROPERTIES OUTPUT_NAME vsgopenvrviewer)
 
 install(TARGETS example_vr)
 

--- a/example_vr.cpp
+++ b/example_vr.cpp
@@ -14,6 +14,10 @@ int main(int argc, char **argv) {
     auto options = vsg::Options::create();
     arguments.read(options);
 
+   // add relative data path based on binary dir
+    vsg::Path dataPath = vsg::filePath(vsg::executableFilePath());
+    dataPath.append(VSGVR_REL_DATADIR);
+    options->paths.push_back(dataPath);
     vsg::Path filename = "world.vsgt";
     if (argc > 1)
       filename = arguments[1];
@@ -29,8 +33,8 @@ int main(int argc, char **argv) {
     // Initialise vr, and add nodes to the scene graph for each tracked device
     // TODO: If controllers are off when program starts they won't be added later
     auto vr = vsgvr::OpenVRContext::create();
-    auto controllerNodeLeft = vsg::read_cast<vsg::Node>("controller.vsgt");
-    auto controllerNodeRight = vsg::read_cast<vsg::Node>("controller2.vsgt");
+    auto controllerNodeLeft = vsg::read_cast<vsg::Node>("controller.vsgt", options);
+    auto controllerNodeRight = vsg::read_cast<vsg::Node>("controller2.vsgt", options);
     vsgvr::createDeviceNodes(vr, vsg_scene, controllerNodeLeft, controllerNodeRight);
 
     // Create the VR Viewer

--- a/example_vr.cpp
+++ b/example_vr.cpp
@@ -21,16 +21,25 @@ int main(int argc, char **argv) {
     dataPath.append(VSGVR_REL_DATADIR);
     options->paths.push_back(dataPath);
     vsg::Path filename = "world.vsgt";
-    if (argc > 1)
-      filename = arguments[1];
-    if (arguments.errors())
-      return arguments.writeErrorMessages(std::cerr);
+    if (argc > 1) {
+        filename = arguments[1];
+        if (!vsg::fileExists(filename)) {
+            std::cerr << "Could not find file '" << filename << "'" << std::endl;
+            return EXIT_FAILURE;
+        }
+    }
+    if (arguments.errors()) {
+        arguments.writeErrorMessages(std::cerr);
+        return EXIT_FAILURE;
+    }
 
     // load the scene graph
     vsg::ref_ptr<vsg::Group> vsg_scene =
         vsg::read_cast<vsg::Group>(filename, options);
-    if (!vsg_scene)
-      return 0;
+    if (!vsg_scene) {
+        std::cerr << "Could not read the scene graph" << std::endl;
+        return EXIT_FAILURE;
+    }
 
     // Initialise vr, and add nodes to the scene graph for each tracked device
     // TODO: If controllers are off when program starts they won't be added later
@@ -78,7 +87,7 @@ int main(int argc, char **argv) {
   }
   catch( const vsg::Exception& e )
   {
-    std::cout << "VSG Exception: " << e.message << std::endl;
+    std::cerr << "VSG Exception: " << e.message << std::endl;
     return EXIT_FAILURE;
   }
 }

--- a/example_vr.cpp
+++ b/example_vr.cpp
@@ -3,6 +3,8 @@
 #include <vsgvr/VRViewer.h>
 #include <vsgvr/openvr/OpenVRContext.h>
 
+#include <iostream>
+
 int main(int argc, char **argv) {
   try
   {

--- a/vsgvr/CMakeLists.txt
+++ b/vsgvr/CMakeLists.txt
@@ -30,6 +30,15 @@ if(WIN32 AND BUILD_SHARED_LIBS)
 else()
     target_compile_options(vsgvr PUBLIC -DVSGVR_DECLSPEC=)
 endif()
+set_target_properties(vsgvr PROPERTIES
+    VERSION ${PROJECT_VERSION_MAJOR}.${PROJECT_VERSION_MINOR}.${PROJECT_VERSION_PATCH}
+    SOVERSION ${VSGVR_SOVERSION}
+)
+if(WIN32)
+    set_target_properties(vsgvr PROPERTIES
+        OUTPUT_NAME vsgvr-${VSGVR_SOVERSION}
+    )
+endif()
 
 install(TARGETS vsgvr ${INSTALL_TARGETS_DEFAULT_FLAGS})
 install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vsgvr)

--- a/vsgvr/CMakeLists.txt
+++ b/vsgvr/CMakeLists.txt
@@ -13,7 +13,7 @@ set( SOURCES
   src/vsgvr/openvr/OpenVRContext.cpp
 )
 
-add_library( vsgvr STATIC ${SOURCES} ${HEADERS} )
+add_library( vsgvr ${SOURCES} ${HEADERS} )
 
 target_include_directories(
   vsgvr PRIVATE
@@ -24,3 +24,9 @@ target_include_directories(
 )
 target_link_libraries( vsgvr PUBLIC vsg::vsg ${OPENVR_LIB})
 target_link_directories( vsgvr PUBLIC ${OPENVR_LIBDIR} )
+if(WIN32 AND BUILD_SHARED_LIBS)
+    target_compile_options(vsgvr PRIVATE "-DVSGVR_DECLSPEC=__declspec(dllexport)")
+    target_compile_options(vsgvr INTERFACE "-DVSGVR_DECLSPEC=__declspec(dllimport)")
+else()
+    target_compile_options(vsgvr PUBLIC -DVSGVR_DECLSPEC=)
+endif()

--- a/vsgvr/CMakeLists.txt
+++ b/vsgvr/CMakeLists.txt
@@ -36,7 +36,11 @@ set_target_properties(vsgvr PROPERTIES
 )
 if(WIN32)
     set_target_properties(vsgvr PROPERTIES
-        OUTPUT_NAME vsgvr-${VSGVR_SOVERSION}
+        OUTPUT_NAME vsgvr-openvr-${VSGVR_SOVERSION}
+    )
+else()
+    set_target_properties(vsgvr PROPERTIES
+        OUTPUT_NAME vsgvr-openvr
     )
 endif()
 

--- a/vsgvr/CMakeLists.txt
+++ b/vsgvr/CMakeLists.txt
@@ -30,3 +30,10 @@ if(WIN32 AND BUILD_SHARED_LIBS)
 else()
     target_compile_options(vsgvr PUBLIC -DVSGVR_DECLSPEC=)
 endif()
+
+install(TARGETS vsgvr ${INSTALL_TARGETS_DEFAULT_FLAGS})
+install(FILES ${HEADERS} DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/vsgvr)
+
+vsg_add_cmake_support_files(
+    CONFIG_TEMPLATE vsgvrConfig.cmake.in
+)

--- a/vsgvr/CMakeLists.txt
+++ b/vsgvr/CMakeLists.txt
@@ -20,7 +20,7 @@ target_include_directories(
   ${PROJECT_SOURCE_DIR}/vr
   ${CMAKE_CURRENT_SOURCE_DIR}/include
   PUBLIC
-  ${OPENVR_ROOT}/headers
+  ${OPENVR_INCLUDE_DIRS}
 )
 target_link_libraries( vsgvr PUBLIC vsg::vsg ${OPENVR_LIB})
 target_link_directories( vsgvr PUBLIC ${OPENVR_LIBDIR} )

--- a/vsgvr/include/vsgvr/UpdateVRVisitor.h
+++ b/vsgvr/include/vsgvr/UpdateVRVisitor.h
@@ -25,7 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <vsgvr/VR.h>
 
 namespace vsgvr {
-class VSG_DECLSPEC UpdateVRVisitor
+class VSGVR_DECLSPEC UpdateVRVisitor
     : public vsg::Inherit<vsg::Visitor, UpdateVRVisitor> {
 public:
   UpdateVRVisitor() = delete;

--- a/vsgvr/include/vsgvr/VR.h
+++ b/vsgvr/include/vsgvr/VR.h
@@ -46,9 +46,9 @@ namespace vsgvr
   };
 
   /// Add a MatrixTransform to the scene for each tracked device
-  void createDeviceNodes(vsg::ref_ptr<vsgvr::VRContext> ctx,
-                         vsg::ref_ptr<vsg::Group> parentNode,
-                         vsg::ref_ptr<vsg::Node> controllerModelLeft = {},
-                         vsg::ref_ptr<vsg::Node> controllerModelRight = {});
+  void VSGVR_DECLSPEC createDeviceNodes(vsg::ref_ptr<vsgvr::VRContext> ctx,
+                                        vsg::ref_ptr<vsg::Group> parentNode,
+                                        vsg::ref_ptr<vsg::Node> controllerModelLeft = {},
+                                        vsg::ref_ptr<vsg::Node> controllerModelRight = {});
 
 } // namespace vsgvr

--- a/vsgvr/include/vsgvr/VRContext.h
+++ b/vsgvr/include/vsgvr/VRContext.h
@@ -30,7 +30,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 namespace vsgvr
 {
-  class VSG_DECLSPEC VRContext : public vsg::Inherit<vsg::Object, VRContext>
+  class VSGVR_DECLSPEC VRContext : public vsg::Inherit<vsg::Object, VRContext>
   {
   public:
     using TrackedDevices = std::map<uint32_t, vsg::ref_ptr<vsgvr::VRDevice>>;

--- a/vsgvr/include/vsgvr/VRController.h
+++ b/vsgvr/include/vsgvr/VRController.h
@@ -27,7 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 namespace vsgvr
 {
-  class VSG_DECLSPEC VRController : public vsg::Inherit<vsgvr::VRDevice, VRController>
+  class VSGVR_DECLSPEC VRController : public vsg::Inherit<vsgvr::VRDevice, VRController>
   {
   public:
     enum class Role

--- a/vsgvr/include/vsgvr/VRDevice.h
+++ b/vsgvr/include/vsgvr/VRDevice.h
@@ -27,7 +27,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 namespace vsgvr
 {
-  class VSG_DECLSPEC VRDevice : public vsg::Inherit<vsg::Object, VRDevice>
+  class VSGVR_DECLSPEC VRDevice : public vsg::Inherit<vsg::Object, VRDevice>
   {
   public:
     enum class DeviceType

--- a/vsgvr/include/vsgvr/VRProjectionMatrix.h
+++ b/vsgvr/include/vsgvr/VRProjectionMatrix.h
@@ -24,7 +24,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <vsg/viewer/ProjectionMatrix.h>
 
 namespace vsgvr {
-class VSG_DECLSPEC VRProjectionMatrix
+class VSGVR_DECLSPEC VRProjectionMatrix
     : public vsg::Inherit<vsg::ProjectionMatrix, VRProjectionMatrix> {
 public:
   VRProjectionMatrix(vsg::mat4 matrix) : mat(matrix) {}

--- a/vsgvr/include/vsgvr/VRProjectionMatrix.h
+++ b/vsgvr/include/vsgvr/VRProjectionMatrix.h
@@ -21,7 +21,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <vsg/viewer/ProjectionMatrix.h>
+#include <vsg/app/ProjectionMatrix.h>
 
 namespace vsgvr {
 class VSGVR_DECLSPEC VRProjectionMatrix

--- a/vsgvr/include/vsgvr/VRViewMatrix.h
+++ b/vsgvr/include/vsgvr/VRViewMatrix.h
@@ -25,7 +25,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <vsg/viewer/ViewMatrix.h>
 
 namespace vsgvr {
-class VSG_DECLSPEC VRViewMatrix
+class VSGVR_DECLSPEC VRViewMatrix
     : public vsg::Inherit<vsg::ViewMatrix, VRViewMatrix> {
 public:
   VRViewMatrix(vsg::mat4 matrix) : mat(matrix) {}

--- a/vsgvr/include/vsgvr/VRViewMatrix.h
+++ b/vsgvr/include/vsgvr/VRViewMatrix.h
@@ -22,7 +22,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <vsg/viewer/ViewMatrix.h>
+#include <vsg/app/ViewMatrix.h>
 
 namespace vsgvr {
 class VSGVR_DECLSPEC VRViewMatrix

--- a/vsgvr/include/vsgvr/VRViewer.h
+++ b/vsgvr/include/vsgvr/VRViewer.h
@@ -26,7 +26,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <vsgvr/VR.h>
 
 namespace vsgvr {
-class VSG_DECLSPEC VRViewer final : public vsg::Inherit<vsg::Viewer, VRViewer> {
+class VSGVR_DECLSPEC VRViewer final : public vsg::Inherit<vsg::Viewer, VRViewer> {
 public:
   VRViewer(vsg::ref_ptr<vsgvr::VRContext> ctx,
            vsg::ref_ptr<vsg::WindowTraits> windowTraits);

--- a/vsgvr/include/vsgvr/VRViewer.h
+++ b/vsgvr/include/vsgvr/VRViewer.h
@@ -21,7 +21,7 @@ IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 */
 
-#include <vsg/viewer/Viewer.h>
+#include <vsg/app/Viewer.h>
 
 #include <vsgvr/VR.h>
 

--- a/vsgvr/include/vsgvr/openvr/OpenVRContext.h
+++ b/vsgvr/include/vsgvr/openvr/OpenVRContext.h
@@ -26,7 +26,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 namespace vsgvr
 {
   class OpenVRContextImpl;
-  class VSG_DECLSPEC OpenVRContext : public vsg::Inherit<vsgvr::VRContext, OpenVRContext>
+  class VSGVR_DECLSPEC OpenVRContext : public vsg::Inherit<vsgvr::VRContext, OpenVRContext>
   {
   public:
     OpenVRContext(vsgvr::VRContext::TrackingOrigin origin = vsgvr::VRContext::TrackingOrigin::Standing);

--- a/vsgvr/src/vsgvr/VRViewer.cpp
+++ b/vsgvr/src/vsgvr/VRViewer.cpp
@@ -148,7 +148,7 @@ VRViewer::createCommandGraphsForView(vsg::ref_ptr<vsg::Node> vsg_scene) {
   // to the vr backend
   auto numImages = m_ctx->numberOfHmdImages();
 
-  vsg::ref_ptr<vsg::CompileTraversal> compile = vsg::CompileTraversal::create(m_desktopWindow);
+  vsg::ref_ptr<vsg::CompileTraversal> compile = vsg::CompileTraversal::create(*this);
   uint32_t hmdWidth = 0, hmdHeight = 0;
   m_ctx->getRecommendedTargetSize(hmdWidth, hmdHeight);
   VkExtent2D hmdExtent{hmdWidth, hmdHeight};

--- a/vsgvr/src/vsgvr/VRViewer.cpp
+++ b/vsgvr/src/vsgvr/VRViewer.cpp
@@ -26,9 +26,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <vsgvr/VRViewMatrix.h>
 
 #include <vsg/core/Exception.h>
-#include <vsg/traversals/ComputeBounds.h>
-#include <vsg/viewer/RenderGraph.h>
-#include <vsg/viewer/View.h>
+#include <vsg/utils/ComputeBounds.h>
+#include <vsg/app/RenderGraph.h>
+#include <vsg/app/View.h>
 
 namespace vsgvr {
 VRViewer::VRViewer(vsg::ref_ptr<vsgvr::VRContext> ctx,
@@ -161,7 +161,7 @@ VRViewer::createCommandGraphsForView(vsg::ref_ptr<vsg::Node> vsg_scene) {
     auto camera = createCameraForScene(vsg_scene, hmdExtent);
     m_hmdCameras.push_back(camera);
     auto renderGraph =
-        createHmdRenderGraph(m_desktopWindow->getDevice(), *compile->contexts.front(),
+        createHmdRenderGraph(m_desktopWindow->getDevice(), context,
                              hmdExtent, image, m_desktopWindow->clearColor());
     hmdImages.push_back(image);
     auto view = vsg::View::create(camera, vsg_scene);
@@ -345,12 +345,10 @@ void VRViewer::submitVRFrames() {
     images.push_back(
         img.colourImage->vk(m_desktopWindow->getDevice()->deviceID));
 
-  m_ctx->submitFrames(images, m_desktopWindow->getDevice()->getDevice(),
-                      m_desktopWindow->getPhysicalDevice()->getPhysicalDevice(),
-                      m_desktopWindow->getInstance()->getInstance(),
-                      m_desktopWindow->getDevice()
-                          ->getQueue(hmdCommandGraph->queueFamily)
-                          ->queue(),
+  m_ctx->submitFrames(images, m_desktopWindow->getDevice()->vk(),
+                      m_desktopWindow->getPhysicalDevice()->vk(),
+                      m_desktopWindow->getInstance()->vk(),
+                      m_desktopWindow->getDevice()->getQueue(hmdCommandGraph->queueFamily)->vk(),
                       hmdCommandGraph->queueFamily, hmdImages.front().width,
                       hmdImages.front().height, hmdImageFormat,
                       VK_SAMPLE_COUNT_1_BIT);

--- a/vsgvr/src/vsgvr/VRViewer.cpp
+++ b/vsgvr/src/vsgvr/VRViewer.cpp
@@ -149,6 +149,11 @@ VRViewer::createCommandGraphsForView(vsg::ref_ptr<vsg::Node> vsg_scene) {
   auto numImages = m_ctx->numberOfHmdImages();
 
   vsg::ref_ptr<vsg::CompileTraversal> compile = vsg::CompileTraversal::create(*this);
+  // when vsg::CompileTraversal is created from a vsg::Viewer instance
+  // compile->context is only filled when
+  // viewer->assignRecordAndSubmitTaskAndPresentation() was called before
+  // vsg::ref_ptr<vsg::CompileTraversal> compile = vsg::CompileTraversal::create(*this);
+  vsg::Context context(m_desktopWindow->getOrCreateDevice());
   uint32_t hmdWidth = 0, hmdHeight = 0;
   m_ctx->getRecommendedTargetSize(hmdWidth, hmdHeight);
   VkExtent2D hmdExtent{hmdWidth, hmdHeight};

--- a/vsgvr/vsgvrConfig.cmake.in
+++ b/vsgvr/vsgvrConfig.cmake.in
@@ -1,0 +1,5 @@
+include(CMakeFindDependencyMacro)
+
+@FIND_DEPENDENCY_OUT@
+
+include("${CMAKE_CURRENT_LIST_DIR}/vsgvrTargets.cmake")


### PR DESCRIPTION
The changes from this pr are used to fix issue https://github.com/geefr/vsgvr/issues/11 and to build binary packages on [OBS](https://build.opensuse.org/package/show/home:rhabacker:branches:games/vsgvr-openvr) for Linux and Windows MinGW. They are consistent, as far as possible, with the changes made by https://github.com/geefr/vsgvr/pull/16.

The openvr-old branch is still used because of the [SteamVR/OpenXR autostarting](https://github.com/geefr/vsgvr/issues/15) issue.