### PR TITLE
Interaction example and user origin fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 .vscode
+build
+

--- a/examples/interaction_locomotion/game.cpp
+++ b/examples/interaction_locomotion/game.cpp
@@ -32,7 +32,9 @@ void Game::loadScene()
   _sceneRoot->addChild(_controllerRight);
 
   _teleportMarker = vsg::Switch::create();
-  _teleportMarker->addChild(false, teleport_marker());
+  auto teleportMatrix = vsg::MatrixTransform::create();
+  _teleportMarker->addChild(false, teleportMatrix);
+  teleportMatrix->addChild(teleport_marker());
   _sceneRoot->addChild(_teleportMarker);
 
   // User origin - The regular vsg scene / world space,

--- a/examples/interaction_locomotion/game.cpp
+++ b/examples/interaction_locomotion/game.cpp
@@ -75,18 +75,25 @@ void Game::initVR()
 
 void Game::initActions()
 {
-  // Configure OpenXR action sets and pose bindings - These allow elements of the OpenXR device tree to be located and tracked in space,
+  // Tracking the location of the user's headset is achieved by tracking the VIEW reference space
+  // vsgvr provides a SpaceBinding class for this - Similar to the ActionPoseBindings the head's pose
+  // will be tracked during rendering, and available when performing interactions
+  _headPose = vsgvr::SpaceBinding::create(_xrInstance, XrReferenceSpaceType::XR_REFERENCE_SPACE_TYPE_VIEW);
+  _vr->spaceBindings.push_back(_headPose);
+
+  // Input devices are tracked via ActionPoseBindings - Tracking elements from the OpenXR device tree in the session space,
   // along with binding the OpenXR input subsystem through to usable actions.
   _baseActionSet = vsgvr::ActionSet::create(_xrInstance, "controller_positions", "Controller Positions");
-  // Pose bindings - One for each hand
+  // Pose bindings
   _leftHandPose = vsgvr::ActionPoseBinding::create(_xrInstance, _baseActionSet, "left_hand", "Left Hand");
   _rightHandPose = vsgvr::ActionPoseBinding::create(_xrInstance, _baseActionSet, "right_hand", "Right Hand");
+
   _baseActionSet->actions = {
     _leftHandPose,
     _rightHandPose,
   };
 
-  _interactions.emplace("teleport", new Interaction_teleport(_xrInstance, _leftHandPose, _teleportMarker, _ground));
+  _interactions.emplace("teleport", new Interaction_teleport(_xrInstance, _headPose, _leftHandPose, _teleportMarker, _ground));
   _interactions.emplace("slide", new Interaction_slide(_xrInstance, _leftHandPose, _ground));
 
   // Ask OpenXR to suggest interaction bindings.

--- a/examples/interaction_locomotion/game.cpp
+++ b/examples/interaction_locomotion/game.cpp
@@ -94,7 +94,7 @@ void Game::initActions()
   };
 
   _interactions.emplace("teleport", new Interaction_teleport(_xrInstance, _headPose, _leftHandPose, _teleportMarker, _ground));
-  _interactions.emplace("slide", new Interaction_slide(_xrInstance, _leftHandPose, _ground));
+  _interactions.emplace("slide", new Interaction_slide(_xrInstance, _headPose, _leftHandPose, _ground));
 
   // Ask OpenXR to suggest interaction bindings.
   // * If subpaths are used, list all paths that each action should be bound for

--- a/examples/interaction_locomotion/game.h
+++ b/examples/interaction_locomotion/game.h
@@ -6,6 +6,7 @@
 #include <vsgvr/actions/Action.h>
 #include <vsgvr/actions/ActionSet.h>
 #include <vsgvr/actions/ActionPoseBinding.h>
+#include <vsgvr/actions/SpaceBinding.h>
 
 #include "interaction.h"
 
@@ -48,6 +49,7 @@ private:
   vsg::ref_ptr<vsgvr::ActionSet> _baseActionSet;
   vsg::ref_ptr<vsgvr::ActionPoseBinding> _leftHandPose;
   vsg::ref_ptr<vsgvr::ActionPoseBinding> _rightHandPose;
+  vsg::ref_ptr<vsgvr::SpaceBinding> _headPose;
 
   std::map<std::string, std::unique_ptr<Interaction>> _interactions;
 

--- a/examples/interaction_locomotion/interaction.h
+++ b/examples/interaction_locomotion/interaction.h
@@ -4,6 +4,7 @@
 #include <vsgvr/actions/Action.h>
 #include <vsgvr/actions/ActionSet.h>
 #include <vsgvr/actions/ActionPoseBinding.h>
+#include <vsgvr/actions/SpaceBinding.h>
 
 #include <list>
 #include <map>

--- a/examples/interaction_locomotion/interactions/interaction_slide.cpp
+++ b/examples/interaction_locomotion/interactions/interaction_slide.cpp
@@ -51,7 +51,7 @@ void Interaction_slide::frame(vsg::ref_ptr<vsg::Group> scene, Game& game, double
     if (state.isActive && fabs(state.currentState) > deadZone)
     {
       _rotation += state.currentState * rotateSensitivity * deltaT * -1.0;
-      game.userOrigin()->orientation = vsg::dquat(_rotation, { 0.0, 0.0, 1.0 });
+      // game.userOrigin()->orientation = vsg::dquat(_rotation, { 0.0, 0.0, 1.0 });
     }
   }
 
@@ -73,7 +73,7 @@ void Interaction_slide::frame(vsg::ref_ptr<vsg::Group> scene, Game& game, double
       if (vsg::length(d) > deadZone)
       {
         d *= strafeSensitivity * deltaT;
-        game.userOrigin()->position += d;
+        // game.userOrigin()->position += d;
       }
     }
   }

--- a/examples/interaction_locomotion/interactions/interaction_slide.h
+++ b/examples/interaction_locomotion/interactions/interaction_slide.h
@@ -9,7 +9,8 @@ class Interaction_slide : public Interaction
 {
   public:
     Interaction_slide() = delete;
-    Interaction_slide(vsg::ref_ptr<vsgvr::Instance> xrInstance, 
+    Interaction_slide(vsg::ref_ptr<vsgvr::Instance> xrInstance,
+      vsg::ref_ptr<vsgvr::SpaceBinding> headPose,
       vsg::ref_ptr<vsgvr::ActionPoseBinding> leftHandPose, 
       vsg::ref_ptr<vsg::Group> ground);
 
@@ -24,6 +25,7 @@ class Interaction_slide : public Interaction
     vsg::ref_ptr<vsgvr::Action> _strafeXAction;
     vsg::ref_ptr<vsgvr::Action> _strafeYAction;
     vsg::ref_ptr<vsgvr::Action> _rotateAction;
+    vsg::ref_ptr<vsgvr::SpaceBinding> _headPose;
     vsg::ref_ptr<vsgvr::ActionPoseBinding> _leftHandPose;
 
     vsg::ref_ptr<vsg::Group> _ground;

--- a/examples/interaction_locomotion/interactions/interaction_teleport.cpp
+++ b/examples/interaction_locomotion/interactions/interaction_teleport.cpp
@@ -99,8 +99,7 @@ void Interaction_teleport::frame(vsg::ref_ptr<vsg::Group> scene, Game& game, dou
       {
         if (auto m = child.node->cast<vsg::MatrixTransform>())
         {
-          // TODO: The rotate here shouldn't be needed - we're overriding the root transform in the model however
-          m->matrix = vsg::translate(_teleportPosition) * vsg::rotate(vsg::radians(90.0), {1.0, 0.0, 0.0});
+          m->matrix = vsg::translate(_teleportPosition);
         }
       }
     }

--- a/examples/interaction_locomotion/interactions/interaction_teleport.cpp
+++ b/examples/interaction_locomotion/interactions/interaction_teleport.cpp
@@ -139,6 +139,7 @@ void Interaction_teleport::frame(vsg::ref_ptr<vsg::Group> scene, Game& game, dou
   if( applyRotation || applyTeleport )
   {
     // The player's position in vr space, at 'ground' level
+    // In this case we know the level if the ground from the teleport target
     auto playerPosOrigin = _headPose->getTransform() * vsg::dvec3{ 0.0, 0.0, 0.0 };
     playerPosOrigin.z = _teleportPosition.z;
 
@@ -157,10 +158,11 @@ void Interaction_teleport::frame(vsg::ref_ptr<vsg::Group> scene, Game& game, dou
     // Set the transform from vr origin to position/rotation within scene
     // The initial translate is important as the user is rarely positioned 
     // at the origin of their vr space.
-    game.userOrigin()->matrix =
-      vsg::translate(newPlayerPosScene) *
-      vsg::rotate(vsg::radians(_playerRotation), { 0.0, 0.0, 1.0 }) *
-      vsg::scale(1.0, 1.0, 1.0) *
-      vsg::translate(-playerPosOrigin);
+    game.userOrigin()->setUserInScene(
+      playerPosOrigin, 
+      newPlayerPosScene,
+      vsg::dquat(vsg::radians(_playerRotation), { 0.0, 0.0, 1.0 }),
+      {1.0, 1.0, 1.0}
+    );
   }
 }

--- a/examples/interaction_locomotion/interactions/interaction_teleport.h
+++ b/examples/interaction_locomotion/interactions/interaction_teleport.h
@@ -10,6 +10,7 @@ class Interaction_teleport : public Interaction
   public:
     Interaction_teleport() = delete;
     Interaction_teleport(vsg::ref_ptr<vsgvr::Instance> xrInstance, 
+      vsg::ref_ptr<vsgvr::SpaceBinding> headPose,
       vsg::ref_ptr<vsgvr::ActionPoseBinding> leftHandPose,
       vsg::ref_ptr<vsg::Switch> teleportTarget,
       vsg::ref_ptr<vsg::Group> ground);
@@ -23,11 +24,13 @@ class Interaction_teleport : public Interaction
 
     vsg::dvec3 _teleportPosition = {0.0, 0.0, 0.0};
     vsg::ref_ptr<vsg::Switch> _teleportTarget;
+    vsg::ref_ptr<vsgvr::SpaceBinding> _headPose;
     vsg::ref_ptr<vsgvr::ActionPoseBinding> _leftHandPose;
 
     bool _teleportButtonDown = false;
     bool _teleportTargetValid = false;
     int _rotateActionState = 0; // -1 is rot left, 1 is rot right
+
     double _playerRotation = 0.0;
 
     vsg::ref_ptr<vsg::Group> _ground;

--- a/vsgvr/CMakeLists.txt
+++ b/vsgvr/CMakeLists.txt
@@ -2,6 +2,7 @@
 set( HEADERS_ACTIONS
   include/vsgvr/actions/Action.h
   include/vsgvr/actions/ActionPoseBinding.h
+  include/vsgvr/actions/SpaceBinding.h
   include/vsgvr/actions/ActionSet.h
 )
 
@@ -25,6 +26,7 @@ set( HEADERS_XR
 set( SOURCES
   src/vsgvr/actions/Action.cpp
   src/vsgvr/actions/ActionPoseBinding.cpp
+  src/vsgvr/actions/SpaceBinding.cpp
   src/vsgvr/actions/ActionSet.cpp
   src/vsgvr/app/Viewer.cpp
   src/vsgvr/app/UserOrigin.cpp

--- a/vsgvr/include/vsgvr/actions/SpaceBinding.h
+++ b/vsgvr/include/vsgvr/actions/SpaceBinding.h
@@ -1,0 +1,62 @@
+/*
+Copyright(c) 2022 Gareth Francis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#pragma once
+
+#include <vsg/core/Inherit.h>
+
+#include <vsgvr/xr/Common.h>
+#include <vsgvr/xr/Instance.h>
+
+namespace vsgvr {
+    class Session;
+
+    /**
+     * A binding class allowing an XrSpace to be tracked by the Viewer.
+     * The specified reference space will be kept updated during rendering (along with any ActionPoseBindings)
+     * in order to track elements such as the position of the headset (view) space, or user's local space.
+     */
+    class VSGVR_DECLSPEC SpaceBinding : public vsg::Inherit<vsg::Object, SpaceBinding>
+    {
+        public:
+            SpaceBinding(vsg::ref_ptr<Instance> instance, XrReferenceSpaceType spaceType);
+            virtual ~SpaceBinding();
+
+            XrSpace getSpace() const { return _space; }
+
+            bool getTransformValid() const { return _transformValid; }
+            vsg::dmat4 getTransform() const { return _transform; }
+            XrReferenceSpaceType getSpaceType() const { return _spaceType; }
+
+            void createSpace(Session* session);
+            void destroySpace();
+
+            void setSpaceLocation(XrSpaceLocation location);
+        private:
+            XrSpace _space = XR_NULL_HANDLE;
+            XrReferenceSpaceType _spaceType;
+
+            bool _transformValid = false;
+            vsg::dmat4 _transform;
+    };
+}
+
+EVSG_type_name(vsgvr::SpaceBinding);

--- a/vsgvr/include/vsgvr/app/UserOrigin.h
+++ b/vsgvr/include/vsgvr/app/UserOrigin.h
@@ -49,9 +49,38 @@ namespace vsgvr {
 
     vsg::dmat4 transform(const vsg::dmat4& mv) const override { return mv * sceneToUser(); }
 
-    /// Position / orientation of user's origin {0,0,0} within the vsg scene space
-    /// Note: The user themself is not usually at the origin - They may move relative to it, within the real world
+    /// Set the matrix to position the origin within the vsg scene space.
+    /// 
+    /// Note: The user is not usually at the origin, @see setUserInScene.
+    /// 
+    /// @param position The position to set the origin to, within the scene's space
+    /// @param orientation The orientation of the origin, within the scene's space
+    /// @param scale The scale of the origin, within the scene's space
     void setOriginInScene( vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale);
+
+    /// Set the matrix to position th euser within the vsg scene space.
+    ///
+    /// This is similar to setOriginInScene, however accounts for the position of the player
+    /// within the vr space - The origin will be offset by playerFloorPosition.
+    /// 
+    /// playerFloorPosition is typically calculated based on the user's head
+    /// ```c++
+    /// // Enable tracking of the headset - View space in OpenXR
+    /// headPose = vsgvr::SpaceBinding::create(_xrInstance, XrReferenceSpaceType::XR_REFERENCE_SPACE_TYPE_VIEW);
+    /// viewer->spaceBindings.push_back(_headPose);
+    /// 
+    /// // The position on the ground, beneath the player
+    /// // This assumes the user is standing on a flat plane, and that z == 0 in vr space
+    /// // aligns with z == 0 in scene space (An intersection in scene space may be preferred)
+    /// auto playerGroundPosition = _headPose->getTransform() * vsg::dvec3{ 0.0, 0.0, 0.0 };
+    /// playerPosUser.z = 0.0;
+    /// ```
+    /// 
+    /// @param playerGroundPosition A position on the floor, directly beneath the player, in the vr space
+    /// @param position The position to set the origin to, within the scene's space
+    /// @param orientation The orientation of the origin, within the scene's space
+    /// @param scale The scale of the origin, within the scene's space
+    void setUserInScene( vsg::dvec3 playerGroundPosition, vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale);
 
     vsg::dmat4 matrix;
   };

--- a/vsgvr/include/vsgvr/app/UserOrigin.h
+++ b/vsgvr/include/vsgvr/app/UserOrigin.h
@@ -21,33 +21,43 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 #pragma once
 
-#include <vsg/nodes/Transform.h>
+#include <vsg/nodes/MatrixTransform.h>
 #include <vsg/maths/transform.h>
 
 namespace vsgvr {
 
-  /// A node which allows the vsgvr origin to be set within the scene
-  /// via position, rotation, and scale.
+  /// A transform node which allows the vsgvr::Viewer origin to be set within the
+  /// scene via position, rotation, and scale.
   /// 
-  /// This node functions in the same way as vsg::MatrixTransform, but is intended
-  /// to transform the whole scene to position the user as needed, within the scene,
-  /// as world space is defined by the OpenXR / vsgvr session (The user's play area).
+  /// This node functions in the same way as vsg::MatrixTransform, but will
+  /// transform a child vsg scene to position the user as needed.
+  /// Note that under vsgvr world space is defined by the OpenXR / vsgvr session,
+  /// based on the user's physical play area.
   /// 
-  /// Also provided are the following functions, to provide transforms between
-  /// the XR world space and vsg world space.
-  /// * userToScene
-  /// * sceneToUser
-  class VSGVR_DECLSPEC UserOrigin : public vsg::Inherit<vsg::Transform, UserOrigin>
+  /// Actions previously performed in 'world' space may remain if they are performed
+  /// within the child scene node(s) of this transform - Desktop base interactions
+  /// should ignore this node, and instead operate directly on the child scene.
+  /// 
+  /// Likewise vr-specific elements such as SpaceBinding, ActionPoseBinding, and
+  /// any nodes which represent controllers / trackers should be added to the root
+  /// of the scene graph, and not as a child of UserOrigin - These elements are
+  /// tracked within the user's physical play area, rather than within the 
+  /// vsg scene.
+  class VSGVR_DECLSPEC UserOrigin : public vsg::Inherit<vsg::MatrixTransform, UserOrigin>
   {
   public:
     UserOrigin();
-    explicit UserOrigin(vsg::dmat4 in_matrix);
-    explicit UserOrigin(vsg::dvec3 in_position, vsg::dquat in_orientation, vsg::dvec3 in_scale = {1.0, 1.0, 1.0});
 
-    vsg::dmat4 userToScene() const { return matrix; }
-    vsg::dmat4 sceneToUser() const { return vsg::inverse(matrix); }
+    explicit UserOrigin(vsg::dmat4 matrix);
 
-    vsg::dmat4 transform(const vsg::dmat4& mv) const override { return mv * sceneToUser(); }
+    /// @see setOriginInScene.
+    explicit UserOrigin(vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale);
+
+    /// @see setUserInScene. 
+    explicit UserOrigin(vsg::dvec3 playerGroundPosition, vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale);
+
+    vsg::dmat4 userToScene() const { return vsg::inverse(matrix); }
+    vsg::dmat4 sceneToUser() const { return matrix; }
 
     /// Set the matrix to position the origin within the vsg scene space.
     /// 
@@ -56,7 +66,7 @@ namespace vsgvr {
     /// @param position The position to set the origin to, within the scene's space
     /// @param orientation The orientation of the origin, within the scene's space
     /// @param scale The scale of the origin, within the scene's space
-    void setOriginInScene( vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale);
+    void setOriginInScene( vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale );
 
     /// Set the matrix to position th euser within the vsg scene space.
     ///
@@ -80,9 +90,7 @@ namespace vsgvr {
     /// @param position The position to set the origin to, within the scene's space
     /// @param orientation The orientation of the origin, within the scene's space
     /// @param scale The scale of the origin, within the scene's space
-    void setUserInScene( vsg::dvec3 playerGroundPosition, vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale);
-
-    vsg::dmat4 matrix;
+    void setUserInScene( vsg::dvec3 playerGroundPosition, vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale );
   };
 }
 

--- a/vsgvr/include/vsgvr/app/UserOrigin.h
+++ b/vsgvr/include/vsgvr/app/UserOrigin.h
@@ -22,6 +22,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #pragma once
 
 #include <vsg/nodes/Transform.h>
+#include <vsg/maths/transform.h>
 
 namespace vsgvr {
 
@@ -40,19 +41,19 @@ namespace vsgvr {
   {
   public:
     UserOrigin();
+    explicit UserOrigin(vsg::dmat4 in_matrix);
     explicit UserOrigin(vsg::dvec3 in_position, vsg::dquat in_orientation, vsg::dvec3 in_scale = {1.0, 1.0, 1.0});
 
-    vsg::dmat4 userToScene() const;
-    vsg::dmat4 sceneToUser() const;
+    vsg::dmat4 userToScene() const { return matrix; }
+    vsg::dmat4 sceneToUser() const { return vsg::inverse(matrix); }
 
     vsg::dmat4 transform(const vsg::dmat4& mv) const override { return mv * sceneToUser(); }
 
-    /// Origin position within the vsg scene space
-    vsg::dvec3 position;
-    /// Origin orientation within the vsg scene space
-    vsg::dquat orientation;
-    /// Origin scale within the vsg scene space
-    vsg::dvec3 scale = {1.0, 1.0, 1.0};
+    /// Position / orientation of user's origin {0,0,0} within the vsg scene space
+    /// Note: The user themself is not usually at the origin - They may move relative to it, within the real world
+    void setOriginInScene( vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale);
+
+    vsg::dmat4 matrix;
   };
 }
 

--- a/vsgvr/include/vsgvr/app/Viewer.h
+++ b/vsgvr/include/vsgvr/app/Viewer.h
@@ -31,6 +31,9 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 #include <vsgvr/xr/GraphicsBindingVulkan.h>
 #include <vsgvr/xr/Session.h>
 
+#include <vsgvr/actions/ActionSet.h>
+#include <vsgvr/actions/SpaceBinding.h>
+
 #include <vsg/app/CommandGraph.h>
 #include <vsg/app/RecordAndSubmitTask.h>
 #include <vsg/app/CompileManager.h>
@@ -130,6 +133,11 @@ namespace vsgvr {
             void assignRecordAndSubmitTask(std::vector<vsg::ref_ptr<vsg::CommandGraph>> in_commandGraphs);
             void compile(vsg::ref_ptr<vsg::ResourceHints> hints = {});
 
+            // OpenXR spaces, which will be synced along with actions
+            // Typically used for obtaining the position of the headset, via
+            // a binding to the origin of XR_REFERENCE_SPACE_TYPE_VIEW
+            std::vector<vsg::ref_ptr<SpaceBinding>> spaceBindings;
+
             // OpenXR action sets, which will be managed by the viewer / session
             std::vector<vsg::ref_ptr<ActionSet>> actionSets;
             // Active actions sets, which will be synchronised each update
@@ -142,13 +150,16 @@ namespace vsgvr {
             void shutdownAll();
             void getViewConfiguration();
 
+            void syncSpaceBindings();
             void syncActions();
             // Attach action sets to the session and create action spaces
             // This method MUST be called ONCE - After action set bindings
             // have been suggested, and prior to scene rendering.
             // Viewer performs this automatically during the first
             // call to pollEvents
+            void createSpaceBindings();
             void createActionSpacesAndAttachActionSets();
+            void destroySpaceBindings();
             void destroyActionSpaces();
 
             vsg::ref_ptr<Instance> _instance;

--- a/vsgvr/include/vsgvr/xr/Session.h
+++ b/vsgvr/include/vsgvr/xr/Session.h
@@ -49,6 +49,7 @@ namespace vsgvr {
 
             vsg::ref_ptr<Swapchain> getSwapchain(size_t view) const { return _viewData[view].swapchain; }
 
+            /// The session's reference space
             XrSpace getSpace() const { return _space; }
 
             struct Frame
@@ -70,10 +71,10 @@ namespace vsgvr {
 
             vsg::ref_ptr<GraphicsBindingVulkan> _graphicsBinding;
             
-            XrSession _session = 0;
+            XrSession _session = XR_NULL_HANDLE;
             XrSessionState _sessionState = XR_SESSION_STATE_UNKNOWN;
             bool _sessionRunning = false;
-            XrSpace _space = 0;
+            XrSpace _space = XR_NULL_HANDLE;
 
             struct PerViewData
             {

--- a/vsgvr/src/vsgvr/actions/SpaceBinding.cpp
+++ b/vsgvr/src/vsgvr/actions/SpaceBinding.cpp
@@ -1,0 +1,102 @@
+/*
+Copyright(c) 2022 Gareth Francis
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+*/
+
+#include <vsgvr/actions/SpaceBinding.h>
+#include <vsgvr/xr/Instance.h>
+#include <vsgvr/xr/Session.h>
+
+#include <vsg/core/Exception.h>
+#include "../xr/Macros.cpp"
+
+#include <vsg/maths/mat4.h>
+#include <vsg/maths/quat.h>
+#include <vsg/maths/transform.h>
+
+#include <iostream>
+
+namespace vsgvr
+{
+  SpaceBinding::SpaceBinding(vsg::ref_ptr<Instance> instance, XrReferenceSpaceType spaceType)
+  {}
+
+  SpaceBinding::~SpaceBinding()
+  {
+    destroySpace();
+  }
+
+  void SpaceBinding::createSpace(Session* session)
+  {
+    if (_space) throw vsg::Exception({ "Space already created" });
+
+    auto spaceCreateInfo = XrReferenceSpaceCreateInfo();
+    spaceCreateInfo.type = XR_TYPE_REFERENCE_SPACE_CREATE_INFO;
+    spaceCreateInfo.next = nullptr;
+    spaceCreateInfo.poseInReferenceSpace.orientation = XrQuaternionf{ 0.0f, 0.0f, 0.0f, 1.0f };
+    spaceCreateInfo.poseInReferenceSpace.position = XrVector3f{ 0.0f, 0.0f, 0.0f };
+    spaceCreateInfo.referenceSpaceType = XR_REFERENCE_SPACE_TYPE_VIEW;
+    xr_check(xrCreateReferenceSpace(session->getSession(), &spaceCreateInfo, &_space), "Failed to create reference space");
+  }
+
+  void SpaceBinding::destroySpace()
+  {
+    if (_space) {
+      xr_check(xrDestroySpace(_space));
+      _space = 0;
+    }
+  }
+
+  void SpaceBinding::setSpaceLocation(XrSpaceLocation location)
+  {
+    if ((location.locationFlags & XR_SPACE_LOCATION_POSITION_VALID_BIT) &&
+      (location.locationFlags & XR_SPACE_LOCATION_ORIENTATION_VALID_BIT))
+    {
+      _transformValid = true;
+
+      // In the same way as ViewMatrix, poses need some conversion for the VSG space
+      // OpenXR space: x-right, y-up, z-back
+      // VSG/Vulkan space: x-right, y-forward, z-up
+      // * Invert y -> To flip the handedness (x-right, y-back, z-up)
+      // * Rotate clockwise around x -> To move into vsg space (x-right, y-up, z-back)
+      // After this, models are built for vsg space, and default concepts in the api map across
+      //
+      // TODO: Need to double check this, but here the action spaces needed to be un-rotated,
+      //       to compensate for the rotation in ViewMatrix. Not entirely sure why..
+      auto worldRotateMat = vsg::rotate(vsg::PI / 2.0, 1.0, 0.0, 0.0);
+
+      auto q = vsg::dquat(
+        location.pose.orientation.x,
+        location.pose.orientation.y,
+        location.pose.orientation.z,
+        location.pose.orientation.w
+      );
+      auto rotateMat = vsg::rotate(q);
+      auto p = vsg::dvec3(location.pose.position.x, location.pose.position.y, location.pose.position.z);
+      auto translateMat = vsg::translate(p);
+      auto transform = worldRotateMat * translateMat * rotateMat;
+
+      _transform = transform;
+    }
+    else
+    {
+      _transformValid = false;
+    }
+  }
+}

--- a/vsgvr/src/vsgvr/app/UserOrigin.cpp
+++ b/vsgvr/src/vsgvr/app/UserOrigin.cpp
@@ -26,20 +26,17 @@ namespace vsgvr
 {
     UserOrigin::UserOrigin() {}
 
-    UserOrigin::UserOrigin(vsg::dvec3 in_position, vsg::dquat in_orientation, vsg::dvec3 in_scale)
-      : position(in_position)
-      , orientation(in_orientation)
-      , scale(in_scale)
+    UserOrigin::UserOrigin(vsg::dmat4 in_matrix)
+      : matrix(in_matrix)
     {}
 
-    vsg::dmat4 UserOrigin::userToScene() const
+    UserOrigin::UserOrigin(vsg::dvec3 in_position, vsg::dquat in_orientation, vsg::dvec3 in_scale)
     {
-      return vsg::translate(position) * vsg::rotate(orientation) * vsg::scale(scale);
+      setOriginInScene(in_position, in_orientation, in_scale);
     }
 
-    vsg::dmat4 UserOrigin::sceneToUser() const
+    void UserOrigin::setOriginInScene(vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale)
     {
-      return vsg::inverse(userToScene());
+      matrix = vsg::translate(position) * vsg::rotate(orientation) * vsg::scale(scale);
     }
 }
-

--- a/vsgvr/src/vsgvr/app/UserOrigin.cpp
+++ b/vsgvr/src/vsgvr/app/UserOrigin.cpp
@@ -26,29 +26,36 @@ namespace vsgvr
 {
     UserOrigin::UserOrigin() {}
 
-    UserOrigin::UserOrigin(vsg::dmat4 in_matrix)
-      : matrix(in_matrix)
+    UserOrigin::UserOrigin(vsg::dmat4 matrix)
+      : Inherit(matrix)
     {}
 
-    UserOrigin::UserOrigin(vsg::dvec3 in_position, vsg::dquat in_orientation, vsg::dvec3 in_scale)
+    UserOrigin::UserOrigin(vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale)
     {
-      setOriginInScene(in_position, in_orientation, in_scale);
+      setOriginInScene(position, orientation, scale);
+    }
+
+    UserOrigin::UserOrigin(vsg::dvec3 playerGroundPosition, vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale)
+    {
+      setUserInScene(playerGroundPosition, position, orientation, scale);
     }
 
     void UserOrigin::setOriginInScene(vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale)
     {
-      matrix = 
+      matrix = vsg::inverse(
         vsg::translate(position) * 
         vsg::rotate(orientation) * 
-        vsg::scale(scale);
+        vsg::scale(scale)
+      );
     }
 
     void UserOrigin::setUserInScene(vsg::dvec3 playerGroundPosition, vsg::dvec3 newPosition, vsg::dquat orientation, vsg::dvec3 scale)
     {
-      matrix =
+      matrix = vsg::inverse(
         vsg::translate(newPosition) *
         vsg::rotate(orientation) *
         vsg::scale(scale) *
-        vsg::translate(-playerGroundPosition);
+        vsg::translate(-playerGroundPosition)
+      );
     }
 }

--- a/vsgvr/src/vsgvr/app/UserOrigin.cpp
+++ b/vsgvr/src/vsgvr/app/UserOrigin.cpp
@@ -37,6 +37,18 @@ namespace vsgvr
 
     void UserOrigin::setOriginInScene(vsg::dvec3 position, vsg::dquat orientation, vsg::dvec3 scale)
     {
-      matrix = vsg::translate(position) * vsg::rotate(orientation) * vsg::scale(scale);
+      matrix = 
+        vsg::translate(position) * 
+        vsg::rotate(orientation) * 
+        vsg::scale(scale);
+    }
+
+    void UserOrigin::setUserInScene(vsg::dvec3 playerGroundPosition, vsg::dvec3 newPosition, vsg::dquat orientation, vsg::dvec3 scale)
+    {
+      matrix =
+        vsg::translate(newPosition) *
+        vsg::rotate(orientation) *
+        vsg::scale(scale) *
+        vsg::translate(-playerGroundPosition);
     }
 }

--- a/vsgvr/src/vsgvr/xr/Session.cpp
+++ b/vsgvr/src/vsgvr/xr/Session.cpp
@@ -32,7 +32,7 @@ using namespace vsg;
 namespace vsgvr {
 
   Session::Session(vsg::ref_ptr<Instance> instance, vsg::ref_ptr<GraphicsBindingVulkan> graphicsBinding,
-                               VkFormat swapchainFormat, std::vector<XrViewConfigurationView> viewConfigs)
+    VkFormat swapchainFormat, std::vector<XrViewConfigurationView> viewConfigs)
     : _graphicsBinding(graphicsBinding)
   {
     createSession(instance);
@@ -71,10 +71,10 @@ namespace vsgvr {
 
   void Session::createSwapchains(VkFormat swapchainFormat, std::vector<XrViewConfigurationView> viewConfigs)
   {
-    if( !_viewData.empty() ) throw Exception({ "Swapchain already initialised" });
+    if (!_viewData.empty()) throw Exception({ "Swapchain already initialised" });
     if (!_session) throw Exception({ "Unable to create swapchain without session" });
 
-    for( auto& viewConfig : viewConfigs )
+    for (auto& viewConfig : viewConfigs)
     {
       PerViewData v;
       v.swapchain = Swapchain::create(_session, swapchainFormat, viewConfig, _graphicsBinding);
@@ -83,30 +83,30 @@ namespace vsgvr {
       VkSampleCountFlagBits framebufferSamples;
       switch (viewConfig.recommendedSwapchainSampleCount)
       {
-         case 1:
-           framebufferSamples = VK_SAMPLE_COUNT_1_BIT;
-           break;
-         case 2:
-           framebufferSamples = VK_SAMPLE_COUNT_2_BIT;
-           break;
-         case 4:
-           framebufferSamples = VK_SAMPLE_COUNT_4_BIT;
-           break;
-         case 8:
-           framebufferSamples = VK_SAMPLE_COUNT_8_BIT;
-           break;
-         case 16:
-           framebufferSamples = VK_SAMPLE_COUNT_16_BIT;
-           break;
-         case 32:
-           framebufferSamples = VK_SAMPLE_COUNT_32_BIT;
-           break;
-         case 64:
-           framebufferSamples = VK_SAMPLE_COUNT_64_BIT;
-           break;
-         default:
-           framebufferSamples = VK_SAMPLE_COUNT_1_BIT;
-           break;
+      case 1:
+        framebufferSamples = VK_SAMPLE_COUNT_1_BIT;
+        break;
+      case 2:
+        framebufferSamples = VK_SAMPLE_COUNT_2_BIT;
+        break;
+      case 4:
+        framebufferSamples = VK_SAMPLE_COUNT_4_BIT;
+        break;
+      case 8:
+        framebufferSamples = VK_SAMPLE_COUNT_8_BIT;
+        break;
+      case 16:
+        framebufferSamples = VK_SAMPLE_COUNT_16_BIT;
+        break;
+      case 32:
+        framebufferSamples = VK_SAMPLE_COUNT_32_BIT;
+        break;
+      case 64:
+        framebufferSamples = VK_SAMPLE_COUNT_64_BIT;
+        break;
+      default:
+        framebufferSamples = VK_SAMPLE_COUNT_1_BIT;
+        break;
       }
 
       bool multisampling = framebufferSamples != VK_SAMPLE_COUNT_1_BIT;
@@ -268,9 +268,9 @@ namespace vsgvr {
   void Session::destroySession()
   {
     xr_check(xrDestroySpace(_space));
-    _space = 0;
+    _space = XR_NULL_HANDLE;
     xr_check(xrDestroySession(_session));
-    _session = 0;
+    _session = XR_NULL_HANDLE;
   }
 
   void Session::beginSession(XrViewConfigurationType viewConfigurationType)


### PR DESCRIPTION
* SpaceBinding is new - Allows tracking of VIEW space for user's head transform
* Interaction examples account for player's position in their physical space (rotate around player, not around the middle of their lounge)
* UserOrigin is now a MatrixTransform, just one with useful functions for moving the user within the scene








